### PR TITLE
add layerInfos in Legend dijit constructor

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -409,7 +409,8 @@ ready, JSON, array, Color, declare, lang, dom, domGeometry, domAttr, domClass, d
 
                     var legendDiv = toolbar.createTool(tool, panelClass);
                     var legend = new Legend({
-                        map: this.map
+                        map: this.map,
+                        layerInfos: layers
                     }, domConstruct.create("div", {}, legendDiv));
                     domClass.add(legend.domNode, "legend");
                     legend.startup();


### PR DESCRIPTION
include fix to pass results of arcgisUtils.getLegendLayers() in the Legend widget constructor
